### PR TITLE
Split `go-ipfs/thirdparty/todocounter` into `go-todocounter`

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,0 +1,1 @@
+1.0.0: QmW3Dyu5CNxzUkuiHT946pNsQ15D6Hi2ah96Y8LWqgfCfn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+os:
+  - linux
+  - osx
+
+language: go
+
+go:
+    - 1.7
+
+install: true
+
+script:
+  - make deps
+  - go test ./...
+
+cache:
+    directories:
+        - $GOPATH/src/gx
+
+notifications:
+  email: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 libp2p
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+export IPFS_API ?= v04x.ipfs.io
+
+gx:
+	go get -u github.com/whyrusleeping/gx
+	go get -u github.com/whyrusleeping/gx-go
+
+deps: gx
+	gx --verbose install --global
+	gx-go rewrite
+	go get ./...

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # go-todocounter
-A threadsafe counter
+
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
+[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+> A threadsafe counter
+
+## Documenation
+
+See https://godoc.org/github.com/ipfs/go-todocounter.
+
+## Contribute
+
+Feel free to join in. All welcome. Open an [issue](https://github.com/ipfs/todocounter/issues)!
+
+This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+### Want to hack on IPFS?
+
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+
+## License
+
+MIT

--- a/counter.go
+++ b/counter.go
@@ -1,0 +1,118 @@
+package todocounter
+
+import (
+	"sync"
+)
+
+// Counter records things remaining to process. It is needed for complicated
+// cases where multiple goroutines are spawned to process items, and they may
+// generate more items to process. For example, say a query over a set of nodes
+// may yield either a result value, or more nodes to query. Signaling is subtly
+// complicated, because the queue may be empty while items are being processed,
+// that will end up adding more items to the queue.
+//
+// Use Counter like this:
+//
+//    todos := make(chan int, 10)
+//    ctr := todoctr.NewCounter()
+//
+//    process := func(item int) {
+//      fmt.Println("processing %d\n...", item)
+//
+//      // this task may randomly generate more tasks
+//      if rand.Intn(5) == 0 {
+//        todos<- item + 1
+//        ctr.Increment(1) // increment counter for new task.
+//      }
+//
+//      ctr.Decrement(1) // decrement one to signal the task being done.
+//    }
+//
+//    // add some tasks.
+//    todos<- 1
+//    todos<- 2
+//    todos<- 3
+//    todos<- 4
+//    ctr.Increment(4)
+//
+//    for {
+//      select {
+//      case item := <- todos:
+//        go process(item)
+//      case <-ctr.Done():
+//        fmt.Println("done processing everything.")
+//        close(todos)
+//      }
+//    }
+type Counter interface {
+	// Incrememnt adds a number of todos to track.
+	// If the counter is **below** zero, it panics.
+	Increment(i uint32)
+
+	// Decrement removes a number of todos to track.
+	// If the count drops to zero, signals done and destroys the counter.
+	// If the count drops **below** zero, panics. It means you have tried to remove
+	// more things than you added, i.e. sync issues.
+	Decrement(i uint32)
+
+	// Done returns a channel to wait upon. Use it in selects:
+	//
+	//  select {
+	//  case <-ctr.Done():
+	//    // done processing all items
+	//  }
+	//
+	Done() <-chan struct{}
+}
+
+type todoCounter struct {
+	count int32
+	done  chan struct{}
+	sync.RWMutex
+}
+
+// NewSyncCounter constructs a new counter
+func NewSyncCounter() Counter {
+	return &todoCounter{
+		done: make(chan struct{}),
+	}
+}
+
+func (c *todoCounter) Increment(i uint32) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.count < 0 {
+		panic("counter already signaled done. use a new counter.")
+	}
+
+	// increment count
+	c.count += int32(i)
+}
+
+// Decrement removes a number of todos to track.
+// If the count drops to zero, signals done and destroys the counter.
+// If the count drops **below** zero, panics. It means you have tried to remove
+// more things than you added, i.e. sync issues.
+func (c *todoCounter) Decrement(i uint32) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.count < 0 {
+		panic("counter already signaled done. probably have sync issues.")
+	}
+
+	if int32(i) > c.count {
+		panic("decrement amount creater than counter. sync issues.")
+	}
+
+	c.count -= int32(i)
+	if c.count == 0 { // done! signal it.
+		c.count--     // set it to -1 to prevent reuse
+		close(c.done) // a closed channel will always return nil
+	}
+}
+
+func (c *todoCounter) Done() <-chan struct{} {
+	return c.done
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "author": "whyrusleeping",
+  "bugs": {
+    "url": "https://github.com/ipfs/go-todocounter/issues"
+  },
+  "gx": {
+    "dvcsimport": "github.com/ipfs/go-todocounter"
+  },
+  "gxVersion": "0.8.0",
+  "language": "go",
+  "license": "MIT",
+  "name": "go-todocounter",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Split `go-ipfs/thirdparty/todocounter` into `go-todocounter`for use in `go-libp2p-kad-dht`.
